### PR TITLE
Reversed "up" and "down" event direction

### DIFF
--- a/src/contact.js
+++ b/src/contact.js
@@ -721,10 +721,10 @@ class Vector {
 		else {
 			// up or down
 			if (this.startPoint.y < this.endPoint.y){
-				this.direction = DIRECTION_UP;
+				this.direction = DIRECTION_DOWN;
 			}
 			else {
-				this.direction = DIRECTION_DOWN;
+				this.direction = DIRECTION_UP;
 			}
 		}
 		


### PR DESCRIPTION
Hit an issue when trying to detect a panning element's collision with the sides of the window/an outer element.

Given:
- a set of booleans for whether the element is `colliding?` and with which boundaries `t? b? l? r?`
- a symbol `d` for `e.detail.local.direction`

```clojure
(if (or (not colliding?)
        (and colliding?
            (or (and t? (= d "down"))
                (and b? (= d "up"))
                (and l? (= d "right"))
                (and r? (= d "left")))))
  (translate-according-to-global-deltas...) ; then
  (log-to-console) ; else
```
The checks for right and left would work, but up and down are reversed. Code is cljs but behavior is the same in js. After checking my code I realized it was in the actual event object.

<details>

<summary>Devtools output for e.detail</summary>

```javascript
{contact: Contact, recognizer: Pan, global: {…}, live: {…}}
  contact: Contact {options: {…}, DEBUG: false, id: 1649786205370, pointerInputs: {…}, activePointerInputs: {…}, …}
  global:
    deltaX: 0
    deltaY: -37.78631591796875
    direction: "down"
    distance: 37.78631591796875
    rotation: 0
    scale: 1
    speed: 0.3235129787992604
    speedX: 0
    speedY: -0.3235129787992604
    srcEvent: PointerEvent {isTrusted: true, pointerId: 1, width: 1, height: 1, pressure: 0.5, …}
  live:
    center: {x: 447.9598388671875, y: 479.17156982421875}
    deltaX: 0
    deltaY: -30.96844482421875
    direction: "down"
    distance: 30.96844482421875
    rotation: 0
    scale: 1
    speed: 309.6844482421875
    speedX: NaN
    speedY: NaN
    srcEvent: PointerEvent {isTrusted: true, pointerId: 1, width: 1, height: 1, pressure: 0.5, …}
```

</details>

If `deltaY` is negative, the element has moved up.

<details>
<summary>See the source where direction is calculated..</summary>

https://github.com/biodiv/contactjs/blob/dbbb27b5cc5791857010532112ffbcea996a5501/src/contact.js#L721-L728

</details>

Either the directions or the start/endpoint should be reversed. 😎 