### PR TITLE
Add Proper Handling for `undefined` Pointer in `onPointerUp`

### DIFF
--- a/src/contact.js
+++ b/src/contact.js
@@ -161,7 +161,9 @@ class Contact {
 		this.currentTimestamp = pointerupEvent.timeStamp;
 	
 		var removedPointer = this.pointerInputs[pointerId];
-		removedPointer.onUp(pointerupEvent);
+		if(removedPointer) {
+			removedPointer.onUp(pointerupEvent);
+		}
 		
 		this.removePointer(pointerId);
 		


### PR DESCRIPTION
`v1.4.1` currently has an issue where `removedPointer.onUp(pointerupEvent);` in `onPointerUp` can throw an error due to `removedPointer` being `undefined`.

I've addressed this in this PR, but it would need to be released as `v1.4.2`.

I've created a new branch called `v1.x` which can contain any backported fixes for the `v1.x` series of releases.